### PR TITLE
Adding shrface consult

### DIFF
--- a/README.org
+++ b/README.org
@@ -280,7 +280,7 @@ Please notice, the following features are also disabled:
 However, the following features are still be able to use:
 1. function =shrface-links=
 2. function =shrface-links-counsel=
-3. function =shrface-headlines-counsel=
+3. function =shrface-headline-counsel=
 4. function =shrface-previous-headline=
 5. function =shrface-next-headline=
 6. function =shrface-links-helm=

--- a/README.org
+++ b/README.org
@@ -129,8 +129,8 @@ You can to call =shrface-default-keybindings= to enable the recommended keybindi
   (define-key shrface-mode-map (kbd "C-t") 'shrface-toggle-bullets)
   (define-key shrface-mode-map (kbd "C-j") 'shrface-next-headline)
   (define-key shrface-mode-map (kbd "C-k") 'shrface-previous-headline)
-  (define-key shrface-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm
-  (define-key shrface-mode-map (kbd "M-h") 'shrface-headline-counsel))
+  (define-key shrface-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm or 'shrface-links-consult
+  (define-key shrface-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm or 'shrface-headline-consult
 #+end_src
 
 Since the keybindings may conflict with other modes, such as =nov-mode-map=, =eww-mode-map=, =mu4e-mode-map=. If you want to enable shrface's keybindings on these modes, you have to bind the functions to those maps as well.
@@ -143,8 +143,8 @@ Here is the keybinding example:
   (define-key nov-mode-map (kbd "C-t") 'shrface-toggle-bullets)
   (define-key nov-mode-map (kbd "C-j") 'shrface-next-headline)
   (define-key nov-mode-map (kbd "C-k") 'shrface-previous-headline)
-  (define-key nov-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm
-  (define-key nov-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm
+  (define-key nov-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm or 'shrface-links-consult
+  (define-key nov-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm or 'shrface-headline-consult
 
 (with-eval-after-load 'eww
   (define-key eww-mode-map (kbd "<tab>") 'shrface-outline-cycle)
@@ -152,8 +152,8 @@ Here is the keybinding example:
   (define-key eww-mode-map (kbd "C-t") 'shrface-toggle-bullets)
   (define-key eww-mode-map (kbd "C-j") 'shrface-next-headline)
   (define-key eww-mode-map (kbd "C-k") 'shrface-previous-headline)
-  (define-key eww-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm
-  (define-key eww-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm
+  (define-key eww-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm or 'shrface-links-consult
+  (define-key eww-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm or 'shrface-headline-consult
 
 (with-eval-after-load 'mu4e
   (define-key mu4e-view-mode-map (kbd "<tab>") 'shrface-outline-cycle)
@@ -161,8 +161,8 @@ Here is the keybinding example:
   (define-key mu4e-view-mode-map (kbd "C-t") 'shrface-toggle-bullets)
   (define-key mu4e-view-mode-map (kbd "C-j") 'shrface-next-headline)
   (define-key mu4e-view-mode-map (kbd "C-k") 'shrface-previous-headline)
-  (define-key mu4e-view-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm
-  (define-key mu4e-view-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm
+  (define-key mu4e-view-mode-map (kbd "M-l") 'shrface-links-counsel) ; or 'shrface-links-helm or 'shrface-links-consult
+  (define-key mu4e-view-mode-map (kbd "M-h") 'shrface-headline-counsel)) ; or 'shrface-headline-helm or 'shrface-headline-consult
 #+END_SRC
 
 In additional to the keys provided by ~shrface-mode~, the following features should also work, you can test and find which fits your requirement:
@@ -236,6 +236,13 @@ List all headlines with =helm=.
 - =TAB= to preview the headline
 - =RET= to goto the headline
 
+*** shrface-links-consult
+List all links with =consult=.
+
+*** shrface-headline-consult
+List all headlines with =consult=.
+
+
 *** shrface-next-headline, shrface-previous-headline
 These two headline functions are designed to replace =outline-next-headline= and
 =outline-previous-headline=. They scan the headline number text properties and
@@ -285,6 +292,8 @@ However, the following features are still be able to use:
 5. function =shrface-next-headline=
 6. function =shrface-links-helm=
 7. function =shrface-headline-helm=
+8. function =shrface-links-consult=
+9. function =shrface-headline-consult=
 
 *** Item bullet
 You can configure your favorite item bullet for shrface
@@ -573,6 +582,10 @@ Sometimes a wrong language is detected, but it is still great for highlight, eve
 
 
 * News/Logs
+** =TBD=
+Version ???
+- Add ~shrface-links-consult~
+- Add ~shrface-headline-consult~
 
 ** =2021-01-23=
 Version *2.6.3*:

--- a/shrface.el
+++ b/shrface.el
@@ -63,6 +63,7 @@
   (require 'org-superstar)
   (require 'org-bullets)
   (require 'all-the-icons)
+  (require 'consult)
   (require 'ivy)
   (require 'helm)
   (require 'helm-utils))
@@ -1388,6 +1389,23 @@ jump around the list."
           (goto-char (nth 0 result)))
       (message "Please enable 'helm-mode' before using 'shrface-headline-helm'"))))
 
+(defun shrface-links-consult ()
+  "Use consult to present all urls in order founded in the buffer."
+  (interactive)
+  (let ((start (point)) next url)
+    ;; get the next nearest url
+    (setq next (text-property-not-all
+                (point) (point-max) shrface-href-follow-link-property nil))
+    ;; only if the next url exists
+    (if next
+        (setq url (get-text-property next shrface-href-property)))
+    (if (fboundp 'consult--read)
+        (consult--read (shrface-links-selectable-list)
+                       :prompt "shrface-links:"
+                       :category 'shrface-links-consult
+                       :sort nil)
+      (message "Please install 'consult' before using 'shrface-links-consult'"))))
+
 (defun shrface-links-counsel-set-actions ()
   "Set actions for function `shrface-links-counsel' when call \\[ivy-occur]."
   (if (fboundp 'ivy-set-actions)
@@ -1502,6 +1520,33 @@ jump around the list."
           (goto-char (car result))
           (recenter nil))
       (message "Please enable 'helm-mode' before using 'shrface-headline-helm'"))))
+
+(defun shrface-headline-consult ()
+    "Use consult to show all headlines in order founded in the buffer.
+Current headline will be the one of the candidates to initially select."
+    (interactive)
+    (let ((current (point-min)) (start (1+ (point))) point number)
+      ;; Scan from point-min to (1+ (point)) to find the current headline.
+      ;; (1+ (point)) to include under current point headline into the scan range.
+      (unless (> start (point-max))
+        (while (setq point (text-property-not-all
+                            current start shrface-headline-number-property nil))
+          (setq current (1+ point))))
+
+      (cond ((equal (point) 1) (setq number 0))
+            ((equal (point) 2) (setq number 0))
+            ((equal (point) (point-max)) (setq number 0))
+            (t
+             (ignore-errors (setq number (1- (get-text-property (1- current) shrface-headline-number-property))))))
+
+      ;; Start the consult--read
+      (setq start (point)) ; save the starting point
+      (if (fboundp 'consult--read)
+          (consult--read (shrface-headline-selectable-list)
+                         :prompt "shrface-headline:"
+                         :category 'shrface-headlines-consult
+                         :sort nil)
+        (message "Please install 'consult' before using 'shrface-headlines-consult'"))))
 
 (defun shrface-previous-headline ()
   "Jump to previous headline."

--- a/shrface.el
+++ b/shrface.el
@@ -1379,7 +1379,7 @@ jump around the list."
     (if (fboundp 'helm-comp-read)
         (progn
           (setq result (helm-comp-read
-                      "shrface-headline: " (shrface-links-selectable-list)
+                      "shrface-links: " (shrface-links-selectable-list)
                       :persistent-action
                       (lambda (candidate)
                         (goto-char (nth 0 candidate))


### PR DESCRIPTION
## Fixing minor typos in prompts and docs

75b27b67ee0395287629ec8d27be16c77a92dede


## Adding 'consult' functions

c0d546452d3ecdc3d1b7abfaa4e0537e4ddf1d9e

Adding the following two methods:

- `shrface-links-consult'
- `shrface-headline-consult'

They are cribbed from the Ivy implementation, but don't have the inner
workings of the functions from which their derived.

Closes #14 